### PR TITLE
Fix demo button disappearing due to initial SSE event

### DIFF
--- a/app/swapi/src/App.js
+++ b/app/swapi/src/App.js
@@ -31,7 +31,9 @@ function App() {
       eventSource.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          setProgressUpdates(prev => [...prev, data]);
+          if (data.type !== 'connected') {
+            setProgressUpdates(prev => [...prev, data]);
+          }
         } catch (error) {
           console.error('Error parsing SSE data:', error);
         }

--- a/app/swapi/src/App.test.js
+++ b/app/swapi/src/App.test.js
@@ -1,8 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+beforeAll(() => {
+  global.EventSource = function () {
+    return {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      close: jest.fn()
+    };
+  };
+});
+
+test('renders app header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/Star Wars Natural Language Query/i);
+  expect(header).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- ignore the initial `connected` event from the SSE stream
- mock `EventSource` in the frontend test to avoid runtime errors
- update the React test to check for the actual header text

## Testing
- `npm test --silent` in `server`
- `CI=true npm test --silent` in `app/swapi`

------
https://chatgpt.com/codex/tasks/task_e_686466a8afec832b815cad291b4d6569